### PR TITLE
Add thumbnail for receive message

### DIFF
--- a/DWeChatRobot/ReceiveMessage.cpp
+++ b/DWeChatRobot/ReceiveMessage.cpp
@@ -180,6 +180,7 @@ static void dealMessage(DWORD messageAddr)
     if (jMsg["type"].get<int>() != 10000)
     {
         jMsg["filepath"] = unicode_to_utf8((wchar_t *)READ_WSTRING(messageAddr, 0x1AC).c_str());
+        jMsg["thumbnail"] = unicode_to_utf8((wchar_t *)READ_WSTRING(messageAddr, 0x198).c_str());
         jMsg["extrainfo"] = unicode_to_utf8((wchar_t *)READ_WSTRING(messageAddr, 0x1EC).c_str());
     }
     else


### PR DESCRIPTION
视频文件有时候 filepath 会返回空, 这时候通过 XML 没法获取到保存路径
加上个 thumbnail 的地址备用